### PR TITLE
Add counter for total conntrack table entries

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,10 +6,8 @@ COPY	. .
 RUN	go mod verify
 RUN	./build.sh
 
-FROM	debian:stretch-slim
+FROM	alpine:3.10
 COPY	--from=build /conntrack-stats-exporter/conntrack-stats-exporter /usr/local/sbin/
-RUN	apt-get update \
-&&	apt-get install -y conntrack \
-&&	apt-get clean \
-&&	rm -rf /var/lib/apt/lists/*
+RUN     apk update && apk --no-cache upgrade && \
+        apk --no-cache add conntrack-tools
 ENTRYPOINT [ "/usr/local/sbin/conntrack-stats-exporter" ]

--- a/build.sh
+++ b/build.sh
@@ -3,4 +3,4 @@ set -eux
 
 go mod verify 
 go test ./...
-go build --ldflags="-X pkg.version=$(git describe --dirty)"
+GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build --ldflags="-X pkg.version=$(git describe --dirty)"


### PR DESCRIPTION
Hello! I added one more counter (output from conntrack --counter) and replace docker image to Alpine for less size