### PR TITLE
Allow multiplatform image creation

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -3,4 +3,6 @@ set -eux
 
 go mod verify 
 go test ./...
-GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build --ldflags="-X pkg.version=$(git describe --dirty)"
+ARCH=$(lscpu | grep Architecture | awk '{print $2}')
+PLATFORM=$(if [ "$ARCH" = "aarch64" ]; then echo "arm64"; else echo "amd64"; fi)
+GOOS=linux GOARCH=$PLATFORM CGO_ENABLED=0 go build --ldflags="-X pkg.version=$(git describe --dirty)"


### PR DESCRIPTION
Allow building the images for different CPU architectures (amd64, arm64 etc.).

Tested using **docker buildx build --platform linux/arm64/v8 --pull --load --tag jwkohnen/conntrack-stats-exporter:latest .**