### PR TITLE
Add possibility to get conntrack stats per network namespace

### DIFF
--- a/exporter/conntrack_mock.sh
+++ b/exporter/conntrack_mock.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+
+set -eu
+
+case "$1" in
+  "--stats"):
+    printf "cpu=0   \tfound=13 invalid=11258 insert=1 insert_failed=2 drop=3 early_drop=4 error=5 search_restart=76531\n"
+    printf "cpu=1   \tfound=6 invalid=10298 insert=6 insert_failed=7 drop=8 early_drop=9 error=10 search_restart=64577\n"
+    printf "cpu=2   \tfound=16 invalid=17439 insert=11 insert_failed=12 drop=13 early_drop=14 error=2 search_restart=75364\n"
+    printf "cpu=3   \tfound=15 invalid=12065 insert=0 insert_failed=0 drop=0 early_drop=0 error=0 search_restart=66740\n"
+    ;;
+  "--count"):
+    echo 434
+    ;;
+  "--version"):
+    echo "conntrack v0.0.0-mock (conntrack-stats-exporter)"
+    ;;
+esac

--- a/exporter/exporter.go
+++ b/exporter/exporter.go
@@ -56,7 +56,7 @@ func WithErrorLogWriter(w io.Writer) Option {
 }
 
 func Handler(opts ...Option) http.Handler {
-	cfg := &options{}
+	cfg := new(options)
 	for _, opt := range opts {
 		opt(cfg)
 	}
@@ -117,6 +117,7 @@ func (e *exporter) Collect(ch chan<- prometheus.Metric) {
 
 		panic(err)
 	}
+
 	for metricName, desc := range e.descriptors {
 		for _, metricPerCPU := range metrics {
 			cpu, ok := metricPerCPU["cpu"]
@@ -129,6 +130,7 @@ func (e *exporter) Collect(ch chan<- prometheus.Metric) {
 
 				panic(err)
 			}
+
 			metricValue, ok := metricPerCPU[metricName]
 			if !ok {
 				continue
@@ -150,6 +152,7 @@ func (e *exporter) getMetrics() (metricsPerCPU, error) {
 	if err != nil {
 		return nil, fmt.Errorf("error running the conntrack command: %w", err)
 	}
+
 	metrics := make(metricsPerCPU, len(lines))
 ParseEachOutputLine:
 	for _, line := range lines {
@@ -182,6 +185,7 @@ func (e *exporter) getGeneralCounter(cpu int) (string, error) {
 	defer cancel()
 
 	cmd := exec.CommandContext(ctx, "conntrack", "--count")
+
 	out, err := cmd.Output()
 	if err != nil {
 		return "", fmt.Errorf("error running the conntrack command with the --count flag: %w", err)
@@ -195,12 +199,14 @@ func (e *exporter) callConntrackTool() ([]string, error) {
 	defer cancel()
 
 	cmd := exec.CommandContext(ctx, "conntrack", "--stats")
+
 	out, err := cmd.Output()
 	if err != nil {
 		return nil, fmt.Errorf("error running the conntrack command with the --stats flag: %w", err)
 	}
 
 	scanner := bufio.NewScanner(bytes.NewReader(out))
+
 	var lines []string
 
 	for scanner.Scan() {

--- a/exporter/exporter.go
+++ b/exporter/exporter.go
@@ -89,7 +89,7 @@ type exporter struct {
 	netnsList      []string
 }
 
-// New creates a new conntrack stats exporter.
+// newExporter creates a newExporter conntrack stats exporter
 func newExporter(ops *options) *exporter {
 	scrapeError := make(map[string]int, len(ops.netnsList))
 	for _, netns := range ops.netnsList {

--- a/exporter/exporter.go
+++ b/exporter/exporter.go
@@ -36,23 +36,31 @@ const (
 	promSubSystem = "stats"
 )
 
-var metricNames = []string{
-	"found",
-	"invalid",
-	"ignore",
-	"insert",
-	"insert_failed",
-	"drop",
-	"early_drop",
-	"error",
-	"search_restart",
-	"count",
+var regex = regexp.MustCompile(`([a-z_]+)=(\d+)`)
+
+var metricNames = map[string][]string{
+	"found":          {"cpu", "netns"},
+	"invalid":        {"cpu", "netns"},
+	"ignore":         {"cpu", "netns"},
+	"insert":         {"cpu", "netns"},
+	"insert_failed":  {"cpu", "netns"},
+	"drop":           {"cpu", "netns"},
+	"early_drop":     {"cpu", "netns"},
+	"error":          {"cpu", "netns"},
+	"search_restart": {"cpu", "netns"},
+	"count":          {"netns"},
 }
 
 type Option func(opts *options)
 
+type metricList []map[string]int
+
 func WithErrorLogWriter(w io.Writer) Option {
 	return func(opts *options) { opts.errorLogWriter = w }
+}
+
+func WithNetNs(netnsList []string) Option {
+	return func(opts *options) { opts.netnsList = netnsList }
 }
 
 func Handler(opts ...Option) http.Handler {
@@ -69,6 +77,7 @@ func Handler(opts ...Option) http.Handler {
 
 type options struct {
 	errorLogWriter io.Writer
+	netnsList      []string
 }
 
 // exporter exports stats from the conntrack CLI. The metrics are named with
@@ -76,20 +85,28 @@ type options struct {
 type exporter struct {
 	descriptors    map[string]*prometheus.Desc
 	errorLogWriter io.Writer
+	scrapeError    map[string]int
+	netnsList      []string
 }
 
-// newExporter creates a newExporter conntrack stats exporter.
+// New creates a new conntrack stats exporter.
 func newExporter(ops *options) *exporter {
-	e := &exporter{
-		descriptors:    make(map[string]*prometheus.Desc, len(metricNames)),
-		errorLogWriter: ops.errorLogWriter,
+	scrapeError := make(map[string]int, len(ops.netnsList))
+	for _, netns := range ops.netnsList {
+		scrapeError[netns] = 0
 	}
-
-	for _, mn := range metricNames {
-		e.descriptors[mn] = prometheus.NewDesc(
-			prometheus.BuildFQName(promNamespace, promSubSystem, mn),
-			"Total of conntrack "+mn,
-			[]string{"cpu"},
+	e := &exporter{descriptors: make(map[string]*prometheus.Desc, len(metricNames)), errorLogWriter: ops.errorLogWriter, scrapeError: scrapeError, netnsList: ops.netnsList}
+	e.descriptors["scrape_error"] = prometheus.NewDesc(
+		prometheus.BuildFQName(promNamespace, promSubSystem, "scrape_error"),
+		"Total of error when calling/parsing conntrack command",
+		[]string{"netns"},
+		nil,
+	)
+	for metricName, metricLabels := range metricNames {
+		e.descriptors[metricName] = prometheus.NewDesc(
+			prometheus.BuildFQName(promNamespace, promSubSystem, metricName),
+			"Total of conntrack "+metricName,
+			metricLabels,
 			nil,
 		)
 	}
@@ -107,53 +124,63 @@ func (e *exporter) Describe(ch chan<- *prometheus.Desc) {
 
 // Collect implements the collect method of the prometheus.Collector interface.
 func (e *exporter) Collect(ch chan<- prometheus.Metric) {
-	metrics, err := e.getMetrics()
-	if err != nil {
-		err = fmt.Errorf("error getting metrics: %w", err)
+	metricsPerNetns := make(map[string]metricList)
+	var err error
+	for _, netns := range e.netnsList {
+		metricsPerNetns[netns], err = e.getMetrics(netns)
+		if err != nil {
+			e.scrapeError[netns]++
+			err = fmt.Errorf("error getting metrics: %w", err)
 
-		if e.errorLogWriter != nil {
-			_, _ = fmt.Fprintln(e.errorLogWriter, err)
+			if e.errorLogWriter != nil {
+				_, _ = fmt.Fprintln(e.errorLogWriter, err)
+			}
 		}
-
-		panic(err)
+		metricsPerNetns[netns] = append(metricsPerNetns[netns], map[string]int{"scrape_error": e.scrapeError[netns]})
 	}
-
 	for metricName, desc := range e.descriptors {
-		for _, metricPerCPU := range metrics {
-			cpu, ok := metricPerCPU["cpu"]
-			if !ok {
-				err := fmt.Errorf("no CPU in metric %+v", metricPerCPU)
-
-				if e.errorLogWriter != nil {
-					_, _ = fmt.Fprintln(e.errorLogWriter, err)
+		for netns, metrics := range metricsPerNetns {
+			for _, metric := range metrics {
+				metricValue, ok := metric[metricName]
+				if !ok {
+					continue
 				}
-
-				panic(err)
+				labels := []string{netns}
+				cpu, ok := metric["cpu"]
+				if ok {
+					labels = append([]string{strconv.Itoa(cpu)}, labels...)
+				}
+				ch <- prometheus.MustNewConstMetric(
+					desc,
+					prometheus.CounterValue,
+					float64(metricValue),
+					labels...,
+				)
 			}
-
-			metricValue, ok := metricPerCPU[metricName]
-			if !ok {
-				continue
-			}
-			ch <- prometheus.MustNewConstMetric(
-				desc,
-				prometheus.CounterValue,
-				float64(metricValue),
-				strconv.Itoa(cpu),
-			)
 		}
 	}
 }
 
-type metricsPerCPU []map[string]int
-
-func (e *exporter) getMetrics() (metricsPerCPU, error) {
-	lines, err := e.callConntrackTool()
+func (e *exporter) getMetrics(netns string) (metricList, error) {
+	var lines []string
+	var total string
+	var err error
+	err = execInNetns(netns, func() error {
+		lines, err = e.getConntrackStats()
+		return err
+	})
 	if err != nil {
-		return nil, fmt.Errorf("error running the conntrack command: %w", err)
+		return nil, fmt.Errorf("failed to get conntrack stats: %s", err)
 	}
-
-	metrics := make(metricsPerCPU, len(lines))
+	err = execInNetns(netns, func() error {
+		total, err = e.getConntrackCounter()
+		return err
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to get conntrack counter: %s", err)
+	}
+	lines = append(lines, total)
+	metrics := make(metricList, len(lines))
 ParseEachOutputLine:
 	for _, line := range lines {
 		matches := regex.FindAllStringSubmatch(line, -1)
@@ -172,15 +199,12 @@ ParseEachOutputLine:
 			}
 			metric[key] = value
 		}
-		if cpu, ok := metric["cpu"]; ok {
-			metrics[cpu] = metric
-		}
+		metrics = append(metrics, metric)
 	}
-
 	return metrics, nil
 }
 
-func (e *exporter) getGeneralCounter(cpu int) (string, error) {
+func (e *exporter) getConntrackCounter() (string, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), 3e9)
 	defer cancel()
 
@@ -191,10 +215,10 @@ func (e *exporter) getGeneralCounter(cpu int) (string, error) {
 		return "", fmt.Errorf("error running the conntrack command with the --count flag: %w", err)
 	}
 
-	return fmt.Sprintf("cpu=%d count=%s", cpu, out), nil
+	return fmt.Sprintf("count=%s", out), nil
 }
 
-func (e *exporter) callConntrackTool() ([]string, error) {
+func (e *exporter) getConntrackStats() ([]string, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), 3e9)
 	defer cancel()
 
@@ -204,6 +228,7 @@ func (e *exporter) callConntrackTool() ([]string, error) {
 	if err != nil {
 		return nil, fmt.Errorf("error running the conntrack command with the --stats flag: %w", err)
 	}
+	fmt.Println(out)
 
 	scanner := bufio.NewScanner(bytes.NewReader(out))
 
@@ -216,15 +241,5 @@ func (e *exporter) callConntrackTool() ([]string, error) {
 	if scanner.Err() != nil {
 		return nil, fmt.Errorf("error reading the output of the conntrack command: %w", scanner.Err())
 	}
-
-	total, err := e.getGeneralCounter(len(lines))
-	if err != nil {
-		return nil, fmt.Errorf("error getting the count from the conntrack command: %w", err)
-	}
-
-	lines = append(lines, total)
-
 	return lines, nil
 }
-
-var regex = regexp.MustCompile(`([a-z_]+)=(\d+)`)

--- a/exporter/exporter.go
+++ b/exporter/exporter.go
@@ -65,7 +65,7 @@ func Handler(opts ...Option) http.Handler {
 	reg := prometheus.NewRegistry()
 	reg.MustRegister(newExporter(cfg))
 
-	return promhttp.HandlerFor(reg, promhttp.HandlerOpts{})
+	return promhttp.HandlerFor(reg, promhttp.HandlerOpts{EnableOpenMetrics: true})
 }
 
 type options struct {

--- a/exporter/exporter_test.go
+++ b/exporter/exporter_test.go
@@ -1,0 +1,129 @@
+package exporter_test
+
+import (
+	"bytes"
+	_ "embed"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/jwkohnen/conntrack-stats-exporter/exporter"
+)
+
+//go:embed conntrack_mock.sh
+var conntrackMockScript string
+
+func TestConntrackMock(t *testing.T) {
+	mockConntrackTool(t)
+
+	out, err := exec.Command("conntrack", "--version").CombinedOutput()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !bytes.Equal(out, []byte("conntrack v0.0.0-mock (conntrack-stats-exporter)\n")) {
+		t.Error("whatever it is we've executed, it was not our mock script")
+	}
+}
+
+func TestMetrics(t *testing.T) {
+	mockConntrackTool(t)
+
+	recorder := httptest.NewRecorder()
+	exporter.Handler().ServeHTTP(recorder, httptest.NewRequest("GET", "/", http.NoBody))
+
+	resp := recorder.Result()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("expected 200, got %d", resp.StatusCode)
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for metricName, cpuValues := range map[string][4]int{
+		// not checking "conntrack_stats_count" here, because is has a CPU label by accident and that is subject to change
+		"conntrack_stats_drop":           {3, 8, 13, 0},
+		"conntrack_stats_early_drop":     {4, 9, 14, 0},
+		"conntrack_stats_error":          {5, 10, 2, 0},
+		"conntrack_stats_found":          {13, 6, 16, 15},
+		"conntrack_stats_insert":         {1, 6, 11, 0},
+		"conntrack_stats_insert_failed":  {2, 7, 12, 0},
+		"conntrack_stats_invalid":        {11258, 10298, 17439, 12065},
+		"conntrack_stats_search_restart": {76531, 64577, 75364, 66740},
+	} {
+		t.Run("Header+Type+Metric: "+metricName, func(t *testing.T) {
+			// Apologies for using regex! As a reminder (?m) enables multi-line mode.  This regex is supposed to make
+			// sure the metric is prepended by a HELP as well as a TYPE header and that each type is `counter`.
+			regex := regexp.MustCompile(
+				fmt.Sprintf(
+					`(?m)^# HELP %s.*?\n`+
+						`^# TYPE %s counter\n`+
+						`^%s\{`,
+					metricName, metricName, metricName,
+				),
+			)
+
+			if !regex.Match(body) {
+				t.Errorf("expected to find HELP header, TYPE header and metric for %s, but didn't", metricName)
+			}
+		})
+
+		for cpu, cpuValue := range cpuValues {
+			t.Run(fmt.Sprintf("%s{cpu=%d}", metricName, cpu), func(t *testing.T) {
+				// Again, apologies for using regex.  This regex is supposed to match the metric line for a given CPU
+				// and its value.  The group should match a metric with only cpu label, any label prepending the cpu
+				// label well as any label following the cpu label.  If adding any label to the metric, this regex
+				// should match or this is a bug!
+				regex := regexp.MustCompile(fmt.Sprintf(`(?m)^%s\{(?:[^{}]+?,|)cpu="%d".*\} %d$`,
+					metricName, cpu, cpuValue,
+				))
+
+				if !regex.Match(body) {
+					t.Errorf("expected to find metric for %s{cpu=%d}, but didn't", metricName, cpu)
+				}
+			})
+		}
+	}
+
+	t.Run("conntrack_stats_count", func(t *testing.T) {
+		// A regex again, but this one is not too bad, or is it?
+		regex := regexp.MustCompile(`(?m)^conntrack_stats_count\{.* 434$`)
+
+		if !regex.Match(body) {
+			t.Errorf("expected to find conntrack_stats_count, but didn't")
+		}
+	})
+}
+
+func mockConntrackTool(t *testing.T) {
+	dir := t.TempDir()
+
+	fd, err := os.Create(filepath.Join(dir, "conntrack"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := io.Copy(fd, strings.NewReader(conntrackMockScript)); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := fd.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := os.Chmod(filepath.Join(dir, "conntrack"), 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Setenv("PATH", dir+":"+os.Getenv("PATH"))
+}

--- a/exporter/exporter_test.go
+++ b/exporter/exporter_test.go
@@ -33,7 +33,7 @@ func TestMetrics(t *testing.T) {
 	mockConntrackTool(t)
 
 	recorder := httptest.NewRecorder()
-	exporter.Handler().ServeHTTP(recorder, httptest.NewRequest(http.MethodGet, "/", http.NoBody))
+	exporter.Handler(exporter.WithNetNs([]string{""})).ServeHTTP(recorder, httptest.NewRequest(http.MethodGet, "/", http.NoBody))
 
 	resp := recorder.Result()
 
@@ -77,7 +77,6 @@ func TestMetrics(t *testing.T) {
 					metricName, metricName, metricName,
 				),
 			)
-
 			if !regex.Match(body) {
 				t.Errorf("expected to find HELP header, TYPE header and metric for %s, but didn't", metricName)
 			}

--- a/exporter/netns.go
+++ b/exporter/netns.go
@@ -1,0 +1,68 @@
+//    This file is part of conntrack-stats-exporter.
+//
+//    conntrack-stats-exporter is free software: you can redistribute it and/or
+//    modify it under the terms of the GNU General Public License as published
+//    by the Free Software Foundation, either version 3 of the License, or (at
+//    your option) any later version.
+//
+//    conntrack-stats-exporter is distributed in the hope that it will be
+//    useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+//    Public License for more details.
+//
+//    You should have received a copy of the GNU General Public License along
+//    with conntrack-stats-exporter.  If not, see
+//    <http://www.gnu.org/licenses/>.
+
+package exporter
+
+import (
+	"runtime"
+
+	log "github.com/sirupsen/logrus"
+	"github.com/vishvananda/netns"
+)
+
+func execInNetns(name string, fn func() error) error {
+	if name == "" {
+		return fn()
+	}
+
+	ns, err := netns.GetFromName(name)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		err := ns.Close()
+		if err != nil {
+			log.Error("exec_in_ns: failed to close fd: %w", err)
+		}
+	}()
+
+	if ns > 0 {
+		runtime.LockOSThread()
+		current, err := netns.Get()
+		if err != nil {
+			return err
+		}
+
+		defer func() {
+			err := netns.Set(current)
+			if err != nil {
+				log.Error("exec_in_ns: failed to restore netns: %w", err)
+			}
+			runtime.UnlockOSThread()
+			err = current.Close()
+			if err != nil {
+				log.Error("exec_in_ns: failed to close fd: %w", err)
+			}
+		}()
+
+		err = netns.Set(ns)
+		if err != nil {
+			return err
+		}
+	}
+
+	return fn()
+}

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,8 @@ require (
 	github.com/prometheus/client_model v0.2.0 // indirect
 	github.com/prometheus/common v0.37.0 // indirect
 	github.com/prometheus/procfs v0.8.0 // indirect
+	github.com/sirupsen/logrus v1.6.0
+	github.com/vishvananda/netns v0.0.0-20211101163701-50045581ed74
 	golang.org/x/sys v0.0.0-20220804214406-8e32c043e418 // indirect
 	google.golang.org/protobuf v1.28.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -137,6 +137,7 @@ github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7V
 github.com/julienschmidt/httprouter v1.3.0/go.mod h1:JR6WtHb+2LUe8TCKY3cZOxFyyO8IZAc4RVcycCCAKdM=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
+github.com/konsorten/go-windows-terminal-sequences v1.0.3 h1:CE8S1cTafDpPvMhIxNJKvHsGVBgn1xWYf1NbHQhywc8=
 github.com/konsorten/go-windows-terminal-sequences v1.0.3/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFBFZlji/RkVcI2GknAs/DXo4wKdlNEc=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
@@ -183,12 +184,15 @@ github.com/prometheus/procfs v0.8.0/go.mod h1:z7EfXMXOkbkqb9IINtpCn86r/to3BnA0ua
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=
+github.com/sirupsen/logrus v1.6.0 h1:UBcNElsrwanuuMsnGSlYmtmgbb23qDR5dG+6X6Oo89I=
 github.com/sirupsen/logrus v1.6.0/go.mod h1:7uNnSEd1DgxDLC74fIahvMZmmYsHGZGEOFrfsX/uA88=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
+github.com/vishvananda/netns v0.0.0-20211101163701-50045581ed74 h1:gga7acRE695APm9hlsSMoOoE65U4/TcqNj90mc69Rlg=
+github.com/vishvananda/netns v0.0.0-20211101163701-50045581ed74/go.mod h1:DD4vA1DwXk04H54A1oHXtwZmA0grkVMdPxx/VGLCah0=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
@@ -300,6 +304,7 @@ golang.org/x/sys v0.0.0-20200113162924-86b910548bc1/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200122134326-e047566fdf82/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200202164722-d101bd2416d5/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200212091648-12a6c2dcc1e4/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20200217220822-9197077df867/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200223170610-d5e6a3e2c0ae/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200302150141-5c8b2ff67527/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/main.go
+++ b/main.go
@@ -30,9 +30,6 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/prometheus/client_golang/prometheus"
-	"github.com/prometheus/client_golang/prometheus/promhttp"
-
 	"github.com/jwkohnen/conntrack-stats-exporter/exporter"
 )
 
@@ -57,17 +54,8 @@ func main() {
 	flag.StringVar(&addr, "addr", addr, "TCP address to listen on")
 	flag.Parse()
 
-	reg := prometheus.NewRegistry()
-	reg.MustRegister(exporter.New())
-
 	mux := http.NewServeMux()
-	mux.Handle(
-		path,
-		newAbortHandler(
-			promhttp.HandlerFor(reg, promhttp.HandlerOpts{}),
-		),
-	)
-
+	mux.Handle(path, newAbortHandler(exporter.Handler()))
 	srv := &http.Server{
 		Addr:         addr,
 		Handler:      mux,

--- a/main.go
+++ b/main.go
@@ -97,7 +97,7 @@ func main() {
 		}
 	}()
 
-	_, _ = fmt.Fprintf(os.Stderr, "listening on %s with endpint %q\n", addr, path)
+	_, _ = fmt.Fprintf(os.Stderr, "listening on %s with endpoint %q\n", addr, path)
 	err := srv.ListenAndServe()
 	wg.Wait()
 

--- a/main.go
+++ b/main.go
@@ -26,6 +26,7 @@ import (
 	"os/signal"
 	"runtime"
 	"runtime/debug"
+	"strings"
 	"sync"
 	"syscall"
 	"time"
@@ -50,8 +51,10 @@ func main() {
 
 	addr := ":9371"
 	path := "/metrics"
+	netns := ""
 	flag.StringVar(&path, "path", path, "metrics endpoint path")
 	flag.StringVar(&addr, "addr", addr, "TCP address to listen on")
+	flag.StringVar(&netns, "netns", netns, "List of netns names separated by comma")
 	flag.Parse()
 
 	mux := http.NewServeMux()
@@ -60,6 +63,7 @@ func main() {
 		newAbortHandler(
 			exporter.Handler(
 				exporter.WithErrorLogWriter(os.Stderr),
+				exporter.WithNetNs(strings.Split(netns, ",")),
 			),
 		),
 	)

--- a/main.go
+++ b/main.go
@@ -55,7 +55,15 @@ func main() {
 	flag.Parse()
 
 	mux := http.NewServeMux()
-	mux.Handle(path, newAbortHandler(exporter.Handler()))
+	mux.Handle(
+		path,
+		newAbortHandler(
+			exporter.Handler(
+				exporter.WithErrorLogWriter(os.Stderr),
+			),
+		),
+	)
+
 	srv := &http.Server{
 		Addr:         addr,
 		Handler:      mux,
@@ -89,6 +97,7 @@ func main() {
 		}
 	}()
 
+	_, _ = fmt.Fprintf(os.Stderr, "listening on %s with endpint %q\n", addr, path)
 	err := srv.ListenAndServe()
 	wg.Wait()
 

--- a/main.go
+++ b/main.go
@@ -105,7 +105,7 @@ func main() {
 		os.Exit(128 + int(receivedSignal.(syscall.Signal)))
 	}
 
-	if err != nil && !errors.Is(err, http.ErrServerClosed) {
+	if err != nil {
 		abort(err)
 	}
 }


### PR DESCRIPTION
This PR allows getting conntrack stats per netns with the -netns flag.
A list of netns can be specified if separated by commas.

It is useful when you have a machine having multiple network namespaces / containers and you want to fetch conntrack stats for all of them, but keep exposing metrics in the default / root netns.

For instance on a machine with 2 netns:
```
# ip netns add foo
# ip netns add bar
# ip netns ls
bar
foo
```
Run the exporter to get metrics from these 2 netns:
```
# ./conntrack-stats-exporter -netns foo,bar
```
Scrape metrics
```
curl http://127.0.0.1:9371/metrics
# HELP conntrack_stats_count Total of conntrack count
# TYPE conntrack_stats_count counter
conntrack_stats_count{netns="foo"} 0
conntrack_stats_count{netns="bar"} 0
# HELP conntrack_stats_drop Total of conntrack drop
# TYPE conntrack_stats_drop counter
conntrack_stats_drop{cpu="0",netns="foo"} 0
conntrack_stats_drop{cpu="1",netns="foo"} 0
conntrack_stats_drop{cpu="0",netns="bar"} 0
conntrack_stats_drop{cpu="1",netns="bar"} 0
# HELP conntrack_stats_early_drop Total of conntrack early_drop
# TYPE conntrack_stats_early_drop counter
conntrack_stats_early_drop{cpu="0",netns="foo"} 0
conntrack_stats_early_drop{cpu="1",netns="foo"} 0
conntrack_stats_early_drop{cpu="0",netns="bar"} 0
conntrack_stats_early_drop{cpu="1",netns="bar"} 0
# HELP conntrack_stats_error Total of conntrack error
# TYPE conntrack_stats_error counter
conntrack_stats_error{cpu="0",netns="foo"} 0
conntrack_stats_error{cpu="1",netns="foo"} 0
conntrack_stats_error{cpu="0",netns="bar"} 0
conntrack_stats_error{cpu="1",netns="bar"} 0
# HELP conntrack_stats_found Total of conntrack found
# TYPE conntrack_stats_found counter
conntrack_stats_found{cpu="0",netns="foo"} 0
conntrack_stats_found{cpu="1",netns="foo"} 0
conntrack_stats_found{cpu="0",netns="bar"} 0
conntrack_stats_found{cpu="1",netns="bar"} 0
# HELP conntrack_stats_insert Total of conntrack insert
# TYPE conntrack_stats_insert counter
conntrack_stats_insert{cpu="0",netns="foo"} 0
conntrack_stats_insert{cpu="1",netns="foo"} 0
conntrack_stats_insert{cpu="0",netns="bar"} 0
conntrack_stats_insert{cpu="1",netns="bar"} 0
# HELP conntrack_stats_insert_failed Total of conntrack insert_failed
# TYPE conntrack_stats_insert_failed counter
conntrack_stats_insert_failed{cpu="0",netns="foo"} 0
conntrack_stats_insert_failed{cpu="1",netns="foo"} 0
conntrack_stats_insert_failed{cpu="0",netns="bar"} 0
conntrack_stats_insert_failed{cpu="1",netns="bar"} 0
# HELP conntrack_stats_invalid Total of conntrack invalid
# TYPE conntrack_stats_invalid counter
conntrack_stats_invalid{cpu="0",netns="foo"} 1
conntrack_stats_invalid{cpu="1",netns="foo"} 2
conntrack_stats_invalid{cpu="0",netns="bar"} 1
conntrack_stats_invalid{cpu="1",netns="bar"} 2
# HELP conntrack_stats_scrape_error Total of error when calling/parsing conntrack command
# TYPE conntrack_stats_scrape_error counter
conntrack_stats_scrape_error{netns="foo"} 0
conntrack_stats_scrape_error{netns="bar"} 0
# HELP conntrack_stats_search_restart Total of conntrack search_restart
# TYPE conntrack_stats_search_restart counter
conntrack_stats_search_restart{cpu="0",netns="foo"} 0
conntrack_stats_search_restart{cpu="1",netns="foo"} 0
conntrack_stats_search_restart{cpu="0",netns="bar"} 0
conntrack_stats_search_restart{cpu="1",netns="bar"} 0
```
Note that if you want to get conntrack stats from the current netns (the one from which you run the exporter) and others, you need to pass an empty string in the -netns flag (e.g -netns ,foo,bar)

This PR also includes some refactoring on error handling (return error which raise a `scrape_error` Prom counter instead of panic). 